### PR TITLE
Get available schedules only from Google Calendar

### DIFF
--- a/frontend/src/app/room-detail/time-select/time-select.component.ts
+++ b/frontend/src/app/room-detail/time-select/time-select.component.ts
@@ -175,8 +175,10 @@ export class TimeSelectComponent implements OnInit, OnDestroy {
    */
   handleSyncClick(): void {
     if (!gapi.auth2.getAuthInstance().isSignedIn.get()) {
+      this.googleScheduleService.assignTimeSpan(this.timeSpan);
       this.googleScheduleService.signInGoogle();
     }
+
     this.getSchedules();
   }
 
@@ -185,10 +187,6 @@ export class TimeSelectComponent implements OnInit, OnDestroy {
       setTimeout(() => { this.getSchedules();}, 500);
     } else {
       this.googleScheduleService.getSchedules().then(schedules => {
-        this.schedules = schedules.filter((schedule) => {
-          schedule.start >= this.timeSpan.start;
-          schedule.end <= this.timeSpan.end;
-        });
 
         const calendar = $('#calendar');
 

--- a/frontend/src/app/services/google-schedule.service.ts
+++ b/frontend/src/app/services/google-schedule.service.ts
@@ -2,6 +2,7 @@ import {Injectable, OnDestroy} from '@angular/core';
 import { GoogleApiService } from 'ng-gapi';
 import { Subscription } from 'rxjs/Subscription';
 import { Schedule } from '../models/schedule';
+import { Timespan } from '../models/timespan';
 
 @Injectable()
 export class GoogleScheduleService implements OnDestroy {
@@ -13,6 +14,8 @@ export class GoogleScheduleService implements OnDestroy {
   subscriber: Subscription;
   schedules: Schedule[] = [];
   isInit = false;
+
+  private timeSpan: Timespan;
 
   constructor(private gapiService: GoogleApiService) {
     this.subscriber = this.gapiService.onLoad().subscribe(() => {
@@ -53,6 +56,10 @@ export class GoogleScheduleService implements OnDestroy {
     }
   }
 
+  assignTimeSpan(timeSpan: Timespan): void {
+    this.timeSpan = timeSpan;
+  }
+
   /**
    * Print the summary and start datetime/date of the next ten events in
    * the authorized user's calendar. If no events are found an
@@ -65,10 +72,10 @@ export class GoogleScheduleService implements OnDestroy {
         'params':
           {
             'calendarId': 'primary',
-            'timeMin': (new Date()).toISOString(),
+            'timeMin': this.timeSpan.start.toISOString(),
+            'timeMax': this.timeSpan.end.toISOString(),
             'showDeleted': false,
             'singleEvents': true,
-            'maxResults': 50,
             'orderBy': 'startTime'
           },
       }


### PR DESCRIPTION
To deal with memory and performance issues, I modify the google schedule service to only get the schedules which included in the time span of the room.